### PR TITLE
identicon: add dependency to erlang/egd to fix project in Elixir >=1.5

### DIFF
--- a/identicon/mix.exs
+++ b/identicon/mix.exs
@@ -27,6 +27,8 @@ defmodule Identicon.Mixfile do
   #
   # Type "mix help deps" for more examples and options
   defp deps do
-    []
+    [
+      {:egd, github: "erlang/egd"}
+    ]
   end
 end


### PR DESCRIPTION
Recent versions of Elixir no longer ship with the `egd` library preinstalled. This PR adds `erlang/egd` to the dependency list of the identicon project to fix that problem.

Fix originally seen [here](https://www.udemy.com/the-complete-elixir-and-phoenix-bootcamp-and-tutorial/learn/v4/questions/2198510).