### PR TITLE
Rename deck variable as _deck

### DIFF
--- a/cards/lib/cards.ex
+++ b/cards/lib/cards.ex
@@ -41,7 +41,7 @@ defmodule Cards do
   ## Examples
 
       iex> deck = Cards.create_deck
-      iex> {hand, deck} = Cards.deal(deck, 1)
+      iex> {hand, _deck} = Cards.deal(deck, 1)
       iex> hand
       ["Ace of Spades"]
 


### PR DESCRIPTION
Resolve warning while testing:

```
warning: variable "deck" is unused
  (for doctest at) lib/cards.ex:44
```